### PR TITLE
Add Ability To Customize Reviewers and Fix Encoding Issue

### DIFF
--- a/banter/banter.py
+++ b/banter/banter.py
@@ -10,6 +10,7 @@ def main():
     parser = argparse.ArgumentParser(description='Create Code Reviews')
     parser.add_argument('--setup', action='store_true', help='setup banter configuration')
     parser.add_argument('-t', '--title', help="set title of new review")
+    parser.add_argument("-r" "--reviewers", help="set reviewers of new review")
     parser_results = vars(parser.parse_args())
 
     if parser_results['setup']:
@@ -17,7 +18,7 @@ def main():
     else:
         return create_review(title=parser_results['title'])
 
-def create_review(title=''):
+def create_review(title='', reviewers=""):
     conf = load_config()
     if conf is None:
         return 1
@@ -27,7 +28,7 @@ def create_review(title=''):
     username = conf.get_value('crucible', 'username')
     auth_token = conf.get_value('crucible', 'token')
     project_key = conf.get_value('crucible', 'project_key')
-    reviewers = conf.get_value('crucible', 'reviewers')
+    reviewers = reviewers or conf.get_value('crucible', 'reviewers') 
     diff = patch.clean(sys.stdin.read())
 
     review_id = do_create_review(crucible_conn, username, auth_token, project_key, diff, title)

--- a/banter/banter.py
+++ b/banter/banter.py
@@ -10,15 +10,16 @@ def main():
     parser = argparse.ArgumentParser(description='Create Code Reviews')
     parser.add_argument('--setup', action='store_true', help='setup banter configuration')
     parser.add_argument('-t', '--title', help="set title of new review")
-    parser.add_argument("-r" "--reviewers", help="set reviewers of new review")
+    parser.add_argument("-r", "--reviewers", help="set reviewers of new review")
     parser_results = vars(parser.parse_args())
 
     if parser_results['setup']:
         setup()
     else:
-        return create_review(title=parser_results['title'])
+        return create_review(title=parser_results['title'],
+                             reviewers=parser_results['reviewers'])
 
-def create_review(title='', reviewers=""):
+def create_review(title='', reviewers=''):
     conf = load_config()
     if conf is None:
         return 1

--- a/banter/crucible.py
+++ b/banter/crucible.py
@@ -7,6 +7,8 @@ from . import dict2xml, utils
 class Crucible(object):
     def __init__(self, baseurl):
         self.baseurl = baseurl
+        #This should probably be configurable
+        self.charset = "utf-8"
 
     def get_auth_token(self, username, password):
         request = self.get_auth_token_request(username, password)
@@ -30,6 +32,7 @@ class Crucible(object):
     def create_review(self, token, **kwargs):
         request = self.get_create_review_request(token, **kwargs)
         request['data'] = self.prepare_xml_payload(request['data'])
+        print(request)
         return self.make_request(request)
 
     @staticmethod
@@ -85,11 +88,11 @@ class Crucible(object):
         result += dict2xml.dict2xml(data)
         return result
 
-    @staticmethod
-    def get_headers():
+    def get_headers(self):
         return {
-            'content-type': 'application/xml',
-            'accept': 'application/json'
+            'content-type': ('application/xml;'
+                             'charset={encoding}'.format(encoding=self.charset)),
+            'accept': 'application/json',
         }
 
     def make_request(self, request):
@@ -107,4 +110,4 @@ class Crucible(object):
         return requests.post(utils.combine_url_components(self.baseurl, request['url']),
                              params=request['params'],
                              headers=self.get_headers(),
-                             data=request['data'])
+                             data=request['data'].encode(self.charset))

--- a/banter/crucible.py
+++ b/banter/crucible.py
@@ -32,7 +32,6 @@ class Crucible(object):
     def create_review(self, token, **kwargs):
         request = self.get_create_review_request(token, **kwargs)
         request['data'] = self.prepare_xml_payload(request['data'])
-        print(request)
         return self.make_request(request)
 
     @staticmethod


### PR DESCRIPTION
This pull request is primarily intended to add the ability to customize the reviewers for a given review. (If not passed, the defaults are used) 

Crucible.py was also fixed to correct a unicode encoding issue. I should have split this into a seperate pull request, but I forgot. If you need me to, I can revert the changes to crucible.py, readd them, and attach them to a seperate pull request.
